### PR TITLE
Return up to date CustomerInfo

### DIFF
--- a/src/Maui.RevenueCat.InAppBilling/Models/PurchaseResultDto.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Models/PurchaseResultDto.cs
@@ -7,4 +7,5 @@ public sealed record PurchaseResultDto
     public bool IsSuccess { get; set; }
     public bool IsError => !(ErrorStatus is null);
     public PurchaseErrorStatus? ErrorStatus { get; set; }
+    public CustomerInfoDto? CustomerInfo { get; set; }
 }

--- a/src/Maui.RevenueCat.InAppBilling/Platforms/Android/RevenueCatBillingAndroid.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Platforms/Android/RevenueCatBillingAndroid.cs
@@ -279,6 +279,20 @@ public partial class RevenueCatBilling : IRevenueCatBilling
             return null;
         }
     }
+    public async partial Task<CustomerInfoDto?> GetCustomerInfo(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var customerInfo = await Purchases.SharedInstance.GetCustomerInfoAsync(cancellationToken);
+
+            return CustomerInfoToCustomerInfoDto(customerInfo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"{nameof(GetCustomerInfo)} failed.");
+            return null;
+        }
+    }
 
     internal static CustomerInfoDto CustomerInfoToCustomerInfoDto(CustomerInfo customerInfo)
     {

--- a/src/Maui.RevenueCat.InAppBilling/Platforms/Android/RevenueCatBillingAndroid.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Platforms/Android/RevenueCatBillingAndroid.cs
@@ -146,7 +146,8 @@ public partial class RevenueCatBilling : IRevenueCatBilling
 
         return new PurchaseResultDto
         {
-            IsSuccess = purchaseSuccessInfo.StoreTransaction.PurchaseState == PurchaseState.Purchased
+            IsSuccess = purchaseSuccessInfo.StoreTransaction.PurchaseState == PurchaseState.Purchased,
+            CustomerInfo= CustomerInfoToCustomerInfoDto(purchaseSuccessInfo.CustomerInfo)
         };
     }
     public async partial Task<List<string>> GetActiveSubscriptions(CancellationToken cancellationToken)

--- a/src/Maui.RevenueCat.InAppBilling/Platforms/MacCatalyst/RevenueCatBillingMac.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Platforms/MacCatalyst/RevenueCatBillingMac.cs
@@ -82,6 +82,19 @@ public partial class RevenueCatBilling : IRevenueCatBilling
             Entitlements = new(),
         };
     }
+    public async partial Task<CustomerInfoDto?> GetCustomerInfo(CancellationToken cancellationToken)
+    {
+        return new()
+        {
+            ActiveSubscriptions = new(),
+            AllPurchasedIdentifiers = new(),
+            FirstSeen = DateTime.MinValue,
+            LatestExpirationDate = DateTime.MinValue,
+            ManagementURL = string.Empty,
+            NonConsumablePurchases = new(),
+            Entitlements = new(),
+        };
+    }
 
     internal static partial void EnableDebugLogs(bool enable)
     {

--- a/src/Maui.RevenueCat.InAppBilling/Platforms/iOS/RevenueCatBillingiOS.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Platforms/iOS/RevenueCatBillingiOS.cs
@@ -285,6 +285,20 @@ public partial class RevenueCatBilling : IRevenueCatBilling
             return null;
         }
     }
+    public async partial Task<CustomerInfoDto?> GetCustomerInfo(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var customerInfo = await Purchases.SharedPurchases.GetCustomerInfoAsync(cancellationToken);
+
+            return CustomerInfoToCustomerInfoDto(customerInfo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"{nameof(GetCustomerInfo)} failed.");
+            return null;
+        }
+    }
 
     internal static CustomerInfoDto CustomerInfoToCustomerInfoDto(RCCustomerInfo customerInfo)
     {

--- a/src/Maui.RevenueCat.InAppBilling/Platforms/iOS/RevenueCatBillingiOS.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Platforms/iOS/RevenueCatBillingiOS.cs
@@ -145,7 +145,8 @@ public partial class RevenueCatBilling : IRevenueCatBilling
 
         return new PurchaseResultDto
         {
-            IsSuccess = purchaseSuccessInfo.StoreTransaction.Sk1Transaction.TransactionState == StoreKit.SKPaymentTransactionState.Purchased
+            IsSuccess = purchaseSuccessInfo.StoreTransaction.Sk1Transaction.TransactionState == StoreKit.SKPaymentTransactionState.Purchased,
+            CustomerInfo = CustomerInfoToCustomerInfoDto(purchaseSuccessInfo.CustomerInfo)
         };
     }
     public async partial Task<List<string>> GetActiveSubscriptions(CancellationToken cancellationToken)

--- a/src/Maui.RevenueCat.InAppBilling/Services/IRevenueCatBilling.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Services/IRevenueCatBilling.cs
@@ -20,4 +20,5 @@ public interface IRevenueCatBilling
     Task<CustomerInfoDto?> Login(string appUserId, CancellationToken cancellationToken = default);
     Task<CustomerInfoDto?> Logout(CancellationToken cancellationToken = default);
     Task<CustomerInfoDto?> RestoreTransactions(CancellationToken cancellationToken = default);
+    Task<CustomerInfoDto?> GetCustomerInfo(CancellationToken cancellationToken = default);
 }

--- a/src/Maui.RevenueCat.InAppBilling/Services/RevenueCatBilling.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Services/RevenueCatBilling.cs
@@ -39,6 +39,7 @@ public partial class RevenueCatBilling : IRevenueCatBilling
     public partial Task<CustomerInfoDto?> Login(string appUserId, CancellationToken cancellationToken);
     public partial Task<CustomerInfoDto?> Logout(CancellationToken cancellationToken);
     public partial Task<CustomerInfoDto?> RestoreTransactions(CancellationToken cancellationToken);
+    public partial Task<CustomerInfoDto?> GetCustomerInfo(CancellationToken cancellationToken);
 
     internal static partial void EnableDebugLogs(bool enable);
 }


### PR DESCRIPTION
I have added a method to IRevenueCatBilling and an implementation on each platform that return the latest CustomerInfoDto on request. I have also added CustomerInfo to the return of the Purchase method. Combined, this means the latest CustomerInfo can be obtained at every useful opportunity.