### PR TITLE
Bump Android NuGet dependencies versions

### DIFF
--- a/src/Maui.RevenueCat.Android/Maui.RevenueCat.Android.csproj
+++ b/src/Maui.RevenueCat.Android/Maui.RevenueCat.Android.csproj
@@ -23,7 +23,7 @@
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>embedded</DebugType>
 		<PackageIcon>icon.png</PackageIcon>
-		<Version>7.12.0.0</Version>
+		<Version>7.13.0.0</Version>
 		<PackageReleaseNotes>Bumped to newer RC version</PackageReleaseNotes>
 	</PropertyGroup>
 
@@ -32,23 +32,23 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Xamarin.Android.Google.BillingClient" Version="6.2.1" />
-		<PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.8.0" />
-		<PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.13.1.2" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.7.0.4" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.7.0.4" />
-		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.7.0.4" />
-		<PackageReference Include="Xamarin.GooglePlayServices.Ads.Identifier" Version="118.0.1.11" />
-		<PackageReference Include="Xamarin.Google.Crypto.Tink.Android" Version="1.13.0.3" />
+		<PackageReference Include="Xamarin.Android.Google.BillingClient" Version="7.1.1" />
+		<PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.8.2.1" />
+		<PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.13.1.5" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.6" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.8.6" />
+		<PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.6" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Ads.Identifier" Version="118.1.0.2" />
+		<PackageReference Include="Xamarin.Google.Crypto.Tink.Android" Version="1.15.0.1" />
 		<PackageReference Include="org.jetbrains.kotlin.kotlin.parcelize.runtime" Version="1.5.20.1" />
-		<PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.0.0" />
+		<PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.0.20" />
 		<PackageReference Include="nventive.binding.kotlinx.serialization.json" Version="1.2.2" />
 
 		<!--fixed amazon warnings-->
 		<PackageReference Include="Eddys.Amazon.AppStoreSdk.Binding" Version="3.0.3" />
 
 		<!--fixed build error "androidx.collection.ArrayMapKt is defined multiple times"-->
-		<PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.7.0.2" />
+		<PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Maui.RevenueCat.Android/Maui.RevenueCat.Android.csproj
+++ b/src/Maui.RevenueCat.Android/Maui.RevenueCat.Android.csproj
@@ -23,8 +23,8 @@
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>embedded</DebugType>
 		<PackageIcon>icon.png</PackageIcon>
-		<Version>7.13.0.0</Version>
-		<PackageReleaseNotes>Bumped to newer RC version</PackageReleaseNotes>
+		<Version>7.12.0.1</Version>
+		<PackageReleaseNotes>Bumped NuGet packages to latest versions</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Maui.RevenueCat.InAppBilling/Maui.RevenueCat.csproj
+++ b/src/Maui.RevenueCat.InAppBilling/Maui.RevenueCat.csproj
@@ -31,8 +31,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>4.5.2</Version>
-    <PackageReleaseNotes>Removed redundant files causing long-path error</PackageReleaseNotes>
+    <Version>4.5.3</Version>
+    <PackageReleaseNotes>Bumped Android NuGet package to the latest version</PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- .NET -->
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
-    <PackageReference Include="Kebechet.Maui.RevenueCat.Android" Version="7.12.0" />
+    <PackageReference Include="Kebechet.Maui.RevenueCat.Android" Version="7.12.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Why?**
There are some other NuGet packages out there (In my case, `Plugin.MauiMTAdmob`) which has indirect dependency on `Xamarin.AndroidX.Fragment` version >= 1.8.3. This causes version conflict issue with `Maui.RevenueCat.InAppBilling` as the version here is lower.