### PR TITLE
PeriodType "PREPAID" added

### DIFF
--- a/src/Maui.RevenueCat.InAppBilling/Enums/PeriodType.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Enums/PeriodType.cs
@@ -4,5 +4,6 @@ public enum PeriodType
 {
     Intro,
     Normal,
-    Trial
+    Trial,
+    Prepaid
 }

--- a/src/Maui.RevenueCat.InAppBilling/Platforms/Android/Extensions/PeriodTypeExtensions.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Platforms/Android/Extensions/PeriodTypeExtensions.cs
@@ -9,6 +9,7 @@ internal static class PeriodTypeExtensions
         if (periodType == PeriodTypeNative.Intro) return PeriodType.Intro;
         if (periodType == PeriodTypeNative.Trial) return PeriodType.Trial;
         if (periodType == PeriodTypeNative.Normal) return PeriodType.Normal;
+        if (periodType == PeriodTypeNative.Prepaid) return PeriodType.Prepaid;
         throw new ArgumentException();
     }
 }

--- a/src/Maui.RevenueCat.InAppBilling/Platforms/iOS/Extensions/PeriodTypeExtensions.cs
+++ b/src/Maui.RevenueCat.InAppBilling/Platforms/iOS/Extensions/PeriodTypeExtensions.cs
@@ -14,6 +14,8 @@ internal static class PeriodTypeExtensions
                 return PeriodType.Trial;
             case RCPeriodType.Normal:
                 return PeriodType.Normal;
+            case RCPeriodType.Prepaid:
+                return PeriodType.Prepaid;
             default:
                 throw new ArgumentException();
         }


### PR DESCRIPTION
RC can return the Period Type "Prepaid" from Google Play Store, which resulted in an ArgumentException. If you have a subscription based product, but allow a buyer to buy for one month without automatic renewal.

PeriodType added
Mapping for Android / IOS added

